### PR TITLE
Fixed whereNull() and whereNotNull() failing

### DIFF
--- a/src/Query.php
+++ b/src/Query.php
@@ -205,7 +205,9 @@ class Query {
 
 		// when param2 is null we replace param2 with param one as the
 		// value holder and make param1 to the = operator.
-		if ( is_null( $param2 ) ) {
+		// However, if param1 is either 'is' or 'is not' we need to leave param2 as null.
+		// This is used for the whereNull() and whereNotNull() methods.
+		if ( is_null( $param2 ) && ! in_array( $param1, [ 'is', 'is not' ] ) ) {
 			$param2 = $param1;
 			$param1 = '=';
 		}

--- a/src/Query.php
+++ b/src/Query.php
@@ -207,7 +207,7 @@ class Query {
 		// value holder and make param1 to the = operator.
 		// However, if param1 is either 'is' or 'is not' we need to leave param2 as null.
 		// This is used for the whereNull() and whereNotNull() methods.
-		if ( is_null( $param2 ) && ! in_array( $param1, [ 'is', 'is not' ] ) ) {
+		if ( is_null( $param2 ) && ! in_array( $param1, [ 'is', 'is not' ], true ) ) {
 			$param2 = $param1;
 			$param1 = '=';
 		}


### PR DESCRIPTION
`whereNull()` and `whereNotNull()` are currently broken. The actual `null` literal that needs to be passed to MySQL is being replaced with the string `'is'` or `'is not'` due to an over-aggressive check to see if the operator was excluded.

Example: `whereNull('id')` and `whereNotNull('id')` are returning `WHERE id = 'is'` and `WHERE id = 'is not'` respectively instead of the expected `WHERE id is null` and `WHERE id is not null`.